### PR TITLE
storybook meta 정보 export 추가

### DIFF
--- a/frontend/packages/ui/src/components/Card/Card.stories.tsx
+++ b/frontend/packages/ui/src/components/Card/Card.stories.tsx
@@ -13,6 +13,8 @@ const meta = {
     args: {},
 } satisfies Meta<typeof Card>;
 
+export default meta;
+
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {


### PR DESCRIPTION
## 문제
- #24 에서 발생한 storybook build 오류
- 생성한 meta정보를 export default 해주지 않아서 발생한 문제

## 해결
- `export default meta;`추가

