### PR TITLE
feat : zicdding-class.com app에 ui 패키지tailwind base style 적용

### DIFF
--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5145,6 +5145,7 @@ __metadata:
     ky: "npm:^1.6.0"
     next: "npm:14.2.3"
     postcss: "npm:^8"
+    postcss-import: "npm:^16.1.0"
     react: "npm:^18"
     react-dom: "npm:^18"
     react-hook-form: "npm:^7.52.2"
@@ -9140,6 +9141,19 @@ __metadata:
   peerDependencies:
     postcss: ^8.0.0
   checksum: 10/33c91b7e6b794b5c33d7d7d4730e5f0729c131d2de1ada7fcc116955625a78c3ce613983f019fa9447681795cf3f851e9c38dfbe3f48a2d08a8aef917c70a32a
+  languageName: node
+  linkType: hard
+
+"postcss-import@npm:^16.1.0":
+  version: 16.1.0
+  resolution: "postcss-import@npm:16.1.0"
+  dependencies:
+    postcss-value-parser: "npm:^4.0.0"
+    read-cache: "npm:^1.0.0"
+    resolve: "npm:^1.1.7"
+  peerDependencies:
+    postcss: ^8.0.0
+  checksum: 10/a0877244976b8b8a930adfc8dff9f5f6c251d78649e67aa80e963d11821e6dbc8f8b16fa1d126e8725093d69c77486fc4a6861c823693c068c3192d4879e0b29
   languageName: node
   linkType: hard
 

--- a/frontend/zicdding-class.com/app/globals.css
+++ b/frontend/zicdding-class.com/app/globals.css
@@ -1,9 +1,6 @@
+@import "tailwindcss/base";
+@import "../../packages/ui/src/global.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-:root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
-}

--- a/frontend/zicdding-class.com/package.json
+++ b/frontend/zicdding-class.com/package.json
@@ -26,6 +26,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "postcss": "^8",
+    "postcss-import": "^16.1.0",
     "tailwindcss": "^3.4.1",
     "typescript": "5.3.3"
   }

--- a/frontend/zicdding-class.com/postcss.config.mjs
+++ b/frontend/zicdding-class.com/postcss.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('postcss-load-config').Config} */
 const config = {
   plugins: {
+    "postcss-import": {},
     tailwindcss: {},
   },
 };

--- a/frontend/zicdding-class.com/tailwind.config.ts
+++ b/frontend/zicdding-class.com/tailwind.config.ts
@@ -1,21 +1,14 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  presets: [
+    require("../packages/ui/tailwind.config")
+  ],
   content: [
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "../packages/ui/**/*.{js,ts,jsx,tsx,mdx}",
   ],
-  theme: {
-    extend: {
-      backgroundImage: {
-        "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
-        "gradient-conic":
-          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
-      },
-    },
-  },
-  plugins: [],
 };
 export default config;


### PR DESCRIPTION
## 상황
UI 패키지의 스타일이 zicdding-class.com App에서 적용되지 않는 문제
## 원인
UI 패키지의 tailwind.config와 App의 tailwind.config가 별개로 존재하기 때문에 적용되지 않음. (tailwind는 빌드타임에 설정을 토대로 style을 생성)
## 해결
UI 패키지의 config와 global.css(UI 패키지의 base 스타일)을 App에 적용해줘야함.
## 작업
- ui패키지의 tailwind.config를 zicdding tailwind.config의 preset에 추가
- ui패키지의 global.css를 zicdding의 global.css에서 import (postcss-import 패키지 설치)

- tailwind.config와 global.css에 경로에서 상대경로로 접근했는데, "@zicdding/..."으로 접근시 오류 잘생했습니다 ㅠ 후에 방법을 찾아보겠습니다