### PR TITLE
feat: 공통컴포넌트 수정 -  Input, Tabs

### DIFF
--- a/frontend/packages/ui/src/components/Input/Input.tsx
+++ b/frontend/packages/ui/src/components/Input/Input.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { cn } from '@ui/lib/utils';
 import React, { useState } from 'react';
 import { Icon } from '../Icon';

--- a/frontend/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/frontend/packages/ui/src/components/Tabs/Tabs.tsx
@@ -1,14 +1,13 @@
-import React from 'react';
-import { RadixTabs, RadixTabsContent, RadixTabsList, RadixTabsTrigger } from './RadixTabs';
+import { RadixTabs, RadixTabsList, RadixTabsTrigger } from './RadixTabs';
 
-interface TabsProps {
+interface TabsProps extends Omit<React.ComponentPropsWithoutRef<typeof RadixTabs>, 'onValueChange' | 'onChange'> {
   items: Array<{ title: string; value: string }>;
   onChange: (value: string) => void;
 }
 
-export function Tabs({ items, onChange }: TabsProps) {
+export function Tabs({ items, onChange, ...rest }: TabsProps) {
   return (
-    <RadixTabs onValueChange={onChange}>
+    <RadixTabs onValueChange={onChange} {...rest}>
       <RadixTabsList>
         {items.map((item) => (
           <RadixTabsTrigger key={item.value} value={item.value}>


### PR DESCRIPTION
1. Input 수정
    - 서버 컴포넌트 단에서 사용하지 못해서 공통 Input 컴포넌트 client 로 변경 
2. Tabs 수정 
    - 제한된 props 만 받아서, 기존 shadcn 의 Tabs 의 기본 props 를 받을 수 있도록 변경 